### PR TITLE
Add overriding of sender_id parameter from send_message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    promotexter (0.4.0)
+    promotexter (0.4.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Promotexter::Client.send_message(text: 'This is a test', to: '639171234567')
 # or you can also pass the configurations as arguments
 client = Promotexter::Client.new(api_key:'key', api_secret:'secret', sender_id:'xxxxxx')
 client.send_message(text: 'This is a test', to:'639171234567')
+
+# overriding of sender_id parameter from send_message
+client = Promotexter::Client.new
+client.send_message(text: 'Override sender_id on demand', to: '639171234567', sender_id: 'Sample')
 ```
 If you want to use the delivery reports, head over to your initializer and uncomment the dlr_callback & dlr_reports lines
 

--- a/lib/promotexter/client.rb
+++ b/lib/promotexter/client.rb
@@ -18,6 +18,7 @@ module Promotexter
     def send_message(options={})
       @to   = options.fetch(:to)
       @text = options.fetch(:text)
+      @sender_id = options[:sender_id]
 
       endpoint = API_HOST + '/api/sms'
       uri      = URI(endpoint)

--- a/lib/promotexter/version.rb
+++ b/lib/promotexter/version.rb
@@ -1,3 +1,3 @@
 module Promotexter
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end

--- a/spec/promotexter/client_spec.rb
+++ b/spec/promotexter/client_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe Promotexter::Client do
       end
     end
 
+    context 'overrides sender id when sending message' do
+      it 'should return new sender_id' do
+        stub_request(:post, host).to_return(body: response_body('success.json'))
+        response = client.send_message(to: '639177710296', text: 'hello world', sender_id: 'NEW_SENDER_ID')
+
+        expect(client.sender_id).to eq('NEW_SENDER_ID')
+        expect(response).to be_truthy
+      end
+    end
+
     context 'sending a valid configuration and parameters' do
       it 'should have a success response' do
         stub_request(:post, host).to_return(body: response_body('success.json'), status: 200, headers: {})


### PR DESCRIPTION
Overriding of sender_id parameter from send_message
```ruby
client = Promotexter::Client.new
client.send_message(text: 'Override sender_id on demand', to: '639171234567', sender_id: 'Sample')
```